### PR TITLE
회원가입 로그인

### DIFF
--- a/src/main/java/com/example/lime_education/application/user/UserFacade.java
+++ b/src/main/java/com/example/lime_education/application/user/UserFacade.java
@@ -1,0 +1,21 @@
+package com.example.lime_education.application.user;
+
+import org.springframework.stereotype.Service;
+
+import com.example.lime_education.domain.user.UserInfo;
+import com.example.lime_education.domain.user.UserService;
+import com.example.lime_education.domain.user.UserCommand.RegisterUser;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacade {
+    private final UserService userService;
+
+    public UserInfo registerUser(RegisterUser command) {
+        UserInfo userInfo = userService.registerUser(command);
+        return userInfo;
+    }
+    
+}

--- a/src/main/java/com/example/lime_education/common/util/TokenGenerator.java
+++ b/src/main/java/com/example/lime_education/common/util/TokenGenerator.java
@@ -1,0 +1,16 @@
+package com.example.lime_education.common.util;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class TokenGenerator {
+    private static final int TOKEN_LENGTH = 20;
+
+    public static String randomCharacter(int length) {
+        return RandomStringUtils.randomAlphanumeric(length);
+    }
+
+    public static String randomCharacterWithPrefix(String prefix) {
+        return prefix + randomCharacter(TOKEN_LENGTH - prefix.length());
+    }
+    
+}

--- a/src/main/java/com/example/lime_education/domain/auth/CustomClaims.java
+++ b/src/main/java/com/example/lime_education/domain/auth/CustomClaims.java
@@ -1,0 +1,24 @@
+package com.example.lime_education.domain.auth;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class CustomClaims {
+    private String userToken;
+    private List<String> authorities;
+
+    public CustomClaims() {
+        
+    }
+
+    public CustomClaims(String userToken, List<String> authorities) {
+        this.userToken = userToken;
+        this.authorities = authorities;
+    }
+
+    public static CustomClaims of(String userToken, List<String> authorities) {
+        return new CustomClaims(userToken, authorities);
+    }
+}

--- a/src/main/java/com/example/lime_education/domain/auth/JwtAuthentication.java
+++ b/src/main/java/com/example/lime_education/domain/auth/JwtAuthentication.java
@@ -1,0 +1,18 @@
+package com.example.lime_education.domain.auth;
+
+import lombok.Getter;
+
+@Getter
+public class JwtAuthentication {
+    private String userToken;
+    private String accessToken;
+
+    public JwtAuthentication() {
+
+    }
+
+    public JwtAuthentication(String userToken, String accessToken) {
+        this.userToken = userToken;
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/example/lime_education/domain/auth/JwtAuthenticationProvider.java
+++ b/src/main/java/com/example/lime_education/domain/auth/JwtAuthenticationProvider.java
@@ -1,0 +1,33 @@
+package com.example.lime_education.domain.auth;
+
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import com.example.lime_education.system.security.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider {
+    private final JwtUtil jwtUtil;
+
+    public Authentication authenticate(String accessToken) {
+        CustomClaims claims = jwtUtil.getUserId(accessToken);
+        JwtAuthentication authentication = new JwtAuthentication(claims.getUserToken(), accessToken);
+        List<GrantedAuthority> authorities = getAuthorities(claims.getAuthorities());
+        return UsernamePasswordAuthenticationToken.authenticated(authentication, accessToken, authorities);
+    }
+
+    private List<GrantedAuthority> getAuthorities(List<String> authorities) {
+        return authorities.stream()
+                .map(SimpleGrantedAuthority::new)
+                .map(GrantedAuthority.class::cast)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/lime_education/domain/user/User.java
+++ b/src/main/java/com/example/lime_education/domain/user/User.java
@@ -1,0 +1,56 @@
+package com.example.lime_education.domain.user;
+
+import com.example.lime_education.common.util.TokenGenerator;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class User {
+    private static final String USER_PREFIX = "usr_";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String userToken;
+    private String username;
+    private String email;
+    private String password;
+    
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Getter
+    public enum Role {
+        ROLE_ADMIN("admin"), ROLE_USER("user");
+        private String description;
+
+        Role(String description) {
+            this.description = description;
+        }
+    }
+
+    @Builder
+    public User(String username, String email, String password, String role) {
+        if (username == null || username.length() == 0) throw new IllegalArgumentException("empty username");
+        if (email == null || email.length() == 0) throw new IllegalArgumentException("empty email");
+        if (password == null || password.length() == 0) throw new IllegalArgumentException("empty password");
+
+        this.userToken = TokenGenerator.randomCharacterWithPrefix(USER_PREFIX);
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.role = Role.ROLE_USER;
+    }
+
+    public User() {
+
+    }
+}

--- a/src/main/java/com/example/lime_education/domain/user/UserCommand.java
+++ b/src/main/java/com/example/lime_education/domain/user/UserCommand.java
@@ -1,0 +1,22 @@
+package com.example.lime_education.domain.user;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class UserCommand {
+    @Getter
+    @Builder
+    public static class RegisterUser {
+        private final String username;
+        private final String email;
+        private final String password;
+        
+        public User toEntity(String encryptPassword) {
+            return User.builder()
+                    .email(email)
+                    .password(encryptPassword)
+                    .username(username)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/lime_education/domain/user/UserInfo.java
+++ b/src/main/java/com/example/lime_education/domain/user/UserInfo.java
@@ -1,0 +1,17 @@
+package com.example.lime_education.domain.user;
+
+import lombok.Getter;
+
+@Getter
+public class UserInfo {
+    private final String userToken;
+    private final String username;
+    private final String email;
+
+    public UserInfo(User user) {
+        this.userToken = user.getUserToken();
+        this.username = user.getUsername();
+        this.email = user.getEmail();
+    }
+    
+}

--- a/src/main/java/com/example/lime_education/domain/user/UserService.java
+++ b/src/main/java/com/example/lime_education/domain/user/UserService.java
@@ -1,0 +1,5 @@
+package com.example.lime_education.domain.user;
+
+public interface UserService {
+    UserInfo registerUser(UserCommand.RegisterUser command);
+}

--- a/src/main/java/com/example/lime_education/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/example/lime_education/domain/user/UserServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.lime_education.domain.user;
+
+import org.springframework.stereotype.Component;
+
+import com.example.lime_education.domain.user.UserCommand.RegisterUser;
+import com.example.lime_education.system.common.CustomPasswordEncoder;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+    private final UserStore userStore;
+    private final CustomPasswordEncoder passwordEncoder;
+
+    @Override
+    public UserInfo registerUser(RegisterUser command) {
+        String encryptPassword = passwordEncoder.encodePassword(command.getPassword());
+        User initUser = command.toEntity(encryptPassword);
+        User user = userStore.store(initUser);
+
+        return new UserInfo(user);
+    }
+    
+}

--- a/src/main/java/com/example/lime_education/domain/user/UserStore.java
+++ b/src/main/java/com/example/lime_education/domain/user/UserStore.java
@@ -1,0 +1,5 @@
+package com.example.lime_education.domain.user;
+
+public interface UserStore {
+    User store(User user);
+}

--- a/src/main/java/com/example/lime_education/infrastructure/user/UserRepository.java
+++ b/src/main/java/com/example/lime_education/infrastructure/user/UserRepository.java
@@ -1,0 +1,13 @@
+package com.example.lime_education.infrastructure.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.lime_education.domain.user.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    User findByEmail(String email);
+    
+}

--- a/src/main/java/com/example/lime_education/infrastructure/user/UserStoreImpl.java
+++ b/src/main/java/com/example/lime_education/infrastructure/user/UserStoreImpl.java
@@ -1,0 +1,20 @@
+package com.example.lime_education.infrastructure.user;
+
+import org.springframework.stereotype.Component;
+
+import com.example.lime_education.domain.user.User;
+import com.example.lime_education.domain.user.UserStore;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserStoreImpl implements UserStore {
+    private final UserRepository userRepository;
+
+    @Override
+    public User store(User user) {
+        return userRepository.save(user);
+    }
+    
+}

--- a/src/main/java/com/example/lime_education/interfaces/user/UserController.java
+++ b/src/main/java/com/example/lime_education/interfaces/user/UserController.java
@@ -1,0 +1,34 @@
+package com.example.lime_education.interfaces.user;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.lime_education.application.user.UserFacade;
+import com.example.lime_education.domain.user.UserCommand;
+import com.example.lime_education.domain.user.UserInfo;
+import com.example.lime_education.interfaces.user.UserDto.RegisterRequest;
+import com.example.lime_education.interfaces.user.UserDto.RegisterResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final UserFacade userfacade;
+
+    @PostMapping("/signup")
+    public ResponseEntity<RegisterResponse> registerUser(@Valid @RequestBody RegisterRequest request) {
+        UserCommand.RegisterUser command = request.toCommand();
+        UserInfo userInfo = userfacade.registerUser(command);
+        RegisterResponse response = new RegisterResponse(userInfo);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(response);
+    }
+}

--- a/src/main/java/com/example/lime_education/interfaces/user/UserDto.java
+++ b/src/main/java/com/example/lime_education/interfaces/user/UserDto.java
@@ -1,0 +1,40 @@
+package com.example.lime_education.interfaces.user;
+
+import com.example.lime_education.domain.user.UserCommand;
+import com.example.lime_education.domain.user.UserInfo;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserDto {
+    @Getter
+    @NoArgsConstructor
+    public static class RegisterRequest {
+        @NotNull(message = "email은 필수 입력 값입니다.")
+        private String email;
+
+        @NotNull(message = "username은 필수 입력 값입니다.")
+        private String username;
+
+        @NotNull(message = "password는 필수 입력 값입니다.")
+        private String password;
+
+        public UserCommand.RegisterUser toCommand() {
+            return UserCommand.RegisterUser.builder()
+                    .email(email)
+                    .username(username)
+                    .password(password)
+                    .build();
+        }
+    }
+
+    @Getter
+    public static class RegisterResponse {
+        private String userToken;
+
+        public RegisterResponse(UserInfo userInfo) {
+            this.userToken = userInfo.getUserToken();
+        }
+    }
+}

--- a/src/main/java/com/example/lime_education/system/WebMvcConfig.java
+++ b/src/main/java/com/example/lime_education/system/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.example.lime_education.system;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+        corsRegistry.addMapping("/**")
+            .allowedOrigins("http://localhost")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("Authorization", "Content-Type", "Bearer", "credentials")
+            .exposedHeaders("Authorization", "Usertoken")
+            .allowCredentials(true)
+            .maxAge(3600);
+    }
+}

--- a/src/main/java/com/example/lime_education/system/common/BaseTime.java
+++ b/src/main/java/com/example/lime_education/system/common/BaseTime.java
@@ -1,0 +1,26 @@
+package com.example.lime_education.system.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime {
+    /**
+     * 날짜 데이터는 대부분의 데이터에 포함되는 공통속성
+     * 여러 데이터에서 상속받아 사용할 수 있도록 class 구현
+     */
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+}

--- a/src/main/java/com/example/lime_education/system/common/CustomPasswordEncoder.java
+++ b/src/main/java/com/example/lime_education/system/common/CustomPasswordEncoder.java
@@ -1,0 +1,9 @@
+package com.example.lime_education.system.common;
+
+public interface CustomPasswordEncoder {
+    String encodePassword(String rawPassword);
+
+    boolean matchesPassword(String rawPassword, String encodedPassword);
+
+    boolean noneMatchesPassword(String rawPassword, String encodedPassword);
+}

--- a/src/main/java/com/example/lime_education/system/response/ApiResponse.java
+++ b/src/main/java/com/example/lime_education/system/response/ApiResponse.java
@@ -1,0 +1,5 @@
+package com.example.lime_education.system.response;
+
+public class ApiResponse {
+    
+}

--- a/src/main/java/com/example/lime_education/system/response/ApiResponseDto.java
+++ b/src/main/java/com/example/lime_education/system/response/ApiResponseDto.java
@@ -1,0 +1,5 @@
+package com.example.lime_education.system.response;
+
+public record ApiResponseDto(int code, String message) {
+    
+}

--- a/src/main/java/com/example/lime_education/system/response/ApiResponseHeader.java
+++ b/src/main/java/com/example/lime_education/system/response/ApiResponseHeader.java
@@ -1,0 +1,13 @@
+package com.example.lime_education.system.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class ApiResponseHeader {
+    private int code;
+    private String message;
+}

--- a/src/main/java/com/example/lime_education/system/security/BCryptCustomPasswordEncoder.java
+++ b/src/main/java/com/example/lime_education/system/security/BCryptCustomPasswordEncoder.java
@@ -1,0 +1,29 @@
+package com.example.lime_education.system.security;
+
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.example.lime_education.system.common.CustomPasswordEncoder;
+
+public class BCryptCustomPasswordEncoder implements CustomPasswordEncoder {
+    private final PasswordEncoder passwordEncoder;
+
+    public BCryptCustomPasswordEncoder() {
+        this.passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Override
+    public String encodePassword(String rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matchesPassword(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+
+    @Override
+    public boolean noneMatchesPassword(String rawPassword, String encodedPassword) {
+        return !matchesPassword(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/java/com/example/lime_education/system/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/lime_education/system/security/JwtAuthenticationFilter.java
@@ -1,0 +1,104 @@
+package com.example.lime_education.system.security;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.example.lime_education.system.response.ApiResponseDto;
+import com.example.lime_education.system.utils.CookieUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, CookieUtil cookieUtil) {
+        this.jwtUtil = jwtUtil;
+        this.cookieUtil = cookieUtil;
+        setFilterProcessesUrl("/api/v1/users/login");
+    }
+
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response) throws AuthenticationException {
+        try {
+            LoginRequest loginRequest = new ObjectMapper().readValue(request.getInputStream(),
+                    LoginRequest.class);
+            List<GrantedAuthority> authorities = getAuthorities(List.of("ROLE_USER"));
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            loginRequest.getEmail(),
+                            loginRequest.getPassword(),
+                            authorities
+//                            null
+                    )
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    private List<GrantedAuthority> getAuthorities(List<String> authorities) {
+        return authorities.stream()
+                .map(SimpleGrantedAuthority::new)
+                .map(GrantedAuthority.class::cast)
+                .toList();
+    }
+
+    @Override
+    public void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                         FilterChain chain, Authentication authentication) throws IOException {
+        UserDetailsImpl userDetails = ((UserDetailsImpl) authentication.getPrincipal());
+
+        // Jwt token 생성 access token 생성
+        String token = jwtUtil.createToken(userDetails.getUserId(), userDetails.getEmail());
+        String userToken = "Bearer " + userDetails.getUserToken();
+        System.out.println("user Token" + userToken);
+
+        handleLoginSuccess(response, userDetails, token, userToken);
+    }
+
+    @Override
+    public void unsuccessfulAuthentication(HttpServletRequest request,
+                                           HttpServletResponse response, AuthenticationException failed) throws IOException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType("application/json");
+        String result = new ObjectMapper().writeValueAsString(
+                new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "login failure")
+        );
+
+        response.getOutputStream().print(result);
+    }
+
+    private void handleLoginSuccess(HttpServletResponse response, UserDetailsImpl userDetails, String token, String userToken) throws IOException {
+        // UserRefreshToken userRefreshToken = getOrGenerate(userDetails.getUserId());
+
+        // Add refresh token as a cookie
+//        addRefreshTokenCookie(response, userRefreshToken);
+
+        // cookieUtil.addRefreshTokenCookie(response, userRefreshToken);
+
+        // Add JWT token in the Authorization header
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+        response.addHeader("userToken", userToken);
+
+        // Set response status and content type
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+    }
+
+    
+}

--- a/src/main/java/com/example/lime_education/system/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/lime_education/system/security/JwtAuthorizationFilter.java
@@ -1,0 +1,101 @@
+package com.example.lime_education.system.security;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.example.lime_education.domain.auth.JwtAuthenticationProvider;
+import com.example.lime_education.system.response.ApiResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Claims;
+// import io.jsonwebtoken.lang.Arrays;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final JwtAuthenticationProvider authenticationProvider;
+    // private static final AntPathRequestMatcher SIGNUP_PATH_REQUEST_MATCHER = new AntPathRequestMatcher("/api/v1/users/signup", HttpMethod.POST.toString());
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService, JwtAuthenticationProvider jwtAuthenticationProvider) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+        this.authenticationProvider = jwtAuthenticationProvider;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String[] excludePath = {"/api/v1/users/signup", "/api/v1/users/login"};
+        String path = request.getRequestURI();
+        return Arrays.stream(excludePath).anyMatch(path::startsWith);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // Header에서 jwt 토큰 받아오기
+        String tokenValue = jwtUtil.getTokenFromRequest(request);
+
+        if (StringUtils.hasText(tokenValue)) {
+            // 토큰 검증
+            // if (isNotValidate(request, response, tokenValue)) return;
+
+            // 토큰에서 사용자 정보 가져오기
+            Claims info = getClaims(response, tokenValue);
+            if (info == null) return;
+
+            // 사용자 정보 인증 객체에 담기
+            if (userInfoInAuthentication(tokenValue)) return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private Claims getClaims(HttpServletResponse response, String tokenValue) throws IOException {
+        Claims info;
+
+        try {
+            info = jwtUtil.getUserInfoFromToken(tokenValue);
+        } catch (Exception e) {
+            // JWT 검증에 실패한 경우 처리
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.setContentType("application/json");
+            String result = new ObjectMapper().writeValueAsString(
+                    new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "INVALID_TOKEN")
+            );
+
+            response.getOutputStream().print(result);
+            return null;
+        }
+        return info;
+    }
+
+    private boolean userInfoInAuthentication(String tokenValue) {
+        try {
+            setAuthentication(tokenValue);
+        } catch (Exception e) {
+            // 인증 처리에 실패한 경우 처리
+            log.error(e.getMessage());
+            return true;
+        }
+        return false;
+    }
+
+    // 인증 처리
+    public void setAuthentication(String tokenValue) {
+        Authentication authentication = authenticationProvider.authenticate(tokenValue);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+    
+}

--- a/src/main/java/com/example/lime_education/system/security/JwtUtil.java
+++ b/src/main/java/com/example/lime_education/system/security/JwtUtil.java
@@ -1,0 +1,105 @@
+package com.example.lime_education.system.security;
+
+import java.security.Key;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.example.lime_education.domain.auth.CustomClaims;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class JwtUtil {
+    public static final String AUTHORIZATION_HEADER = "authorization"; // Header KEY 값
+    public static final String BEARER_PREFIX = "Bearer "; // Token 식별자
+    private static final long TOKEN_TIME = Duration.ofDays(5).toMillis(); // 토큰 만료시간 5 days
+
+    @Value("${jwt.secret}") // Base 64 decode시 사용하는 Key
+    private String secretKey;
+    private Key key;
+    private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    public static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
+
+    public enum TokenStatus {
+        VALID,
+        INVALID,
+        EXPIRED
+    }
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(Long userId, String email) {
+        Date date = new Date();
+
+        return BEARER_PREFIX + 
+                Jwts.builder()
+                            .setSubject(email) // 사용자 식별
+                            .claim("id", userId)
+                            .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                            .setIssuedAt(date)
+                            .signWith(key, signatureAlgorithm)
+                            .compact();
+    }
+
+    public TokenStatus validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return TokenStatus.VALID;
+        } catch (SecurityException | MalformedJwtException e) {
+            logger.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+            return TokenStatus.INVALID;
+        } catch (ExpiredJwtException e) {
+            logger.error("Expired JWT token, 만료된 JWT token 입니다.");
+            logger.info("after expired error log");
+            return TokenStatus.EXPIRED;
+
+        } catch (UnsupportedJwtException e) {
+            logger.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+            return TokenStatus.INVALID;
+        } catch (IllegalArgumentException e) {
+            logger.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+            return TokenStatus.INVALID;
+        }
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    public CustomClaims getUserId(String accessToken) {
+        Claims claims = getUserInfoFromToken(accessToken);
+
+        return new CustomClaims(claims.get("token", String.class), List.of("ROLE_USER"));
+    }
+
+    public String getTokenFromRequest(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        } else {
+            throw new IllegalArgumentException("getTokenFromRequest(): BEARER_PREFIX가 Bearer 와 일치하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/lime_education/system/security/LoginRequest.java
+++ b/src/main/java/com/example/lime_education/system/security/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.example.lime_education.system.security;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/lime_education/system/security/SecurityConfig.java
+++ b/src/main/java/com/example/lime_education/system/security/SecurityConfig.java
@@ -1,0 +1,104 @@
+package com.example.lime_education.system.security;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import com.example.lime_education.domain.auth.JwtAuthenticationProvider;
+import com.example.lime_education.system.common.CustomPasswordEncoder;
+import com.example.lime_education.system.utils.CookieUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
+    private UserDetailsServiceImpl userDetailsService;
+    private final JwtAuthenticationProvider authenticationProvider;
+    private AuthenticationConfiguration authenticationConfiguration;
+
+    @Bean
+    public CustomPasswordEncoder customPasswordEncoder() {
+        return new BCryptCustomPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    // Authenticatoin, 토큰에 대해 인증
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, cookieUtil);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+
+        return filter;
+    }
+
+
+    // Authorization, 식별된 사용자에 대해 권한 부여, 인가
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService, authenticationProvider);
+    }
+    
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity, CorsFilter corsFilter) throws Exception {
+        httpSecurity.csrf(AbstractHttpConfigurer::disable)
+                    .httpBasic(AbstractHttpConfigurer::disable)
+                    .formLogin(AbstractHttpConfigurer::disable)
+                    .logout(AbstractHttpConfigurer::disable)
+                    .rememberMe(AbstractHttpConfigurer::disable)
+                    .anonymous(AbstractHttpConfigurer::disable)
+                    .sessionManagement(session -> session
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .addFilter(corsFilter)
+                    .addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class)
+                    .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                    .headers(AbstractHttpConfigurer::disable)
+                    .cors(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(authorize -> authorize
+                            // .requestMatchers(new AntPathRequestMatcher("/api/v1/users/signup", "/api/v1/users/login")).permitAll()
+                            .requestMatchers("/api/v1/users/signup").permitAll()
+                            .requestMatchers("/api/v1/users/login").permitAll()
+                            .anyRequest().authenticated() // 나머지 요청은 인증 필요
+                    );
+
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(
+                List.of("http://localhost:5173", "http://localhost:5174", "http://localhost:4173", "http://localhost"));
+        config.setAllowedMethods(
+                List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowCredentials(true);
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization", "Content-Type", "Bearer", "credentials", "Usertoken"));
+        config.setMaxAge(3600L);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/example/lime_education/system/security/UserDetailsImpl.java
+++ b/src/main/java/com/example/lime_education/system/security/UserDetailsImpl.java
@@ -1,0 +1,73 @@
+package com.example.lime_education.system.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.example.lime_education.domain.user.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+    private final User user;
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getEmail() {
+        return user.getEmail();
+    }
+
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    public String getUserToken() {
+        return user.getUserToken();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        String authority = "ROLE_USER";
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/lime_education/system/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/lime_education/system/security/UserDetailsServiceImpl.java
@@ -1,0 +1,31 @@
+package com.example.lime_education.system.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.example.lime_education.domain.user.User;
+import com.example.lime_education.infrastructure.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public String getUserEmail(Long userId) {
+        User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        return user.getEmail();
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email);
+        return new UserDetailsImpl(user);
+    }
+    
+}

--- a/src/main/java/com/example/lime_education/system/utils/CookieUtil.java
+++ b/src/main/java/com/example/lime_education/system/utils/CookieUtil.java
@@ -1,0 +1,69 @@
+package com.example.lime_education.system.utils;
+
+import java.util.Base64;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.SerializationUtils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class CookieUtil {
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                String name1 = cookie.getName();
+                log.info("refresh Token: " + name1);
+                if (name.equals(cookie.getName())) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (name.equals(cookie.getName())) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object obj) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(obj));
+    }
+
+    @SuppressWarnings("deprecation")
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(
+                SerializationUtils.deserialize(
+                        Base64.getUrlDecoder().decode(cookie.getValue())
+                )
+        );
+    }
+}


### PR DESCRIPTION
JwtAuthenticationFilter, JwtAuthorizationFilter 에서 요청시 필터를 거치지 않기 위해서
JwtAuthorizationFilter 클래스에서 shouldNotFilter() 를 구현하였으며
SecurityConfig 클래스에서 authorizeHttpRequests.requestMatchers() 에 추가하였습니다.

회원가입
- userfacade.registerUser() 메서드로 구현.

로그인
- JwtAuthenticationFilter 클래스에서 setFilterProcessesUrl("/api/v1/users/login") 을 사용하여 해당 URL 을 intercept 하여

성공시
  - attemptAuthentication()
  - successfulAuthentication()
  - handleLoginSuccess()

실패시
  - attemptAuthentication()
  - unsuccessfulAuthentication()

 를 진행하여 로그인 처리를 합니다.

close #1 